### PR TITLE
Add newer facter compatibility symlink

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,6 +37,9 @@ Vagrant.configure("2") do |config|
         puppet_facts["has_local_package_mirror"] = "1"
     end
 
+    # Provide a symlink to relocated facter
+
+    config.vm.provision "shell", inline: "ln -s /opt/puppetlabs/facter /etc/puppetlabs/facter"
 
     # Provision the Vagrant box using Puppet.
 


### PR DESCRIPTION
Newer versions of facter are stored in `/opt/puppetlabs` rather than `/etc/puppetlabs`. This PR adds a symlink to `/opt` to fix the puppet provisioner in the demo.